### PR TITLE
Exit with a non-zero code if the input BAM is missing.

### DIFF
--- a/hairs-src/extracthairs.c
+++ b/hairs-src/extracthairs.c
@@ -321,8 +321,10 @@ int main(int argc, char** argv) {
     }
     if (readsorted == 0 && bamfiles > 0) {
         for (i = 0; i < bamfiles; i++) {
-            if (LONG_READS == 0) parse_bamfile_sorted(bamfilelist[i], &ht, chromvars, varlist, reflist);
-            else parse_bamfile_fosmid(bamfilelist[i], &ht, chromvars, varlist, reflist); // fosmid pool bam file
+			int parse_ok = 0;
+            if (LONG_READS == 0) parse_ok = parse_bamfile_sorted(bamfilelist[i], &ht, chromvars, varlist, reflist);
+            else parse_ok = parse_bamfile_fosmid(bamfilelist[i], &ht, chromvars, varlist, reflist); // fosmid pool bam file
+			if (parse_ok != 0) return parse_ok;
         }
     }
     if (logfile != NULL) fclose(logfile);

--- a/hairs-src/fosmidbam_hairs.c
+++ b/hairs-src/fosmidbam_hairs.c
@@ -326,6 +326,6 @@ int parse_bamfile_fosmid(char* bamfile, HASHTABLE* ht, CHROMVARS* chromvars, VAR
     for (reads = 0; reads < MAX_READS; reads++) free(readlist[reads]);
     free(readlist);
     bam_destroy1(b);
-    return 1;
+    return 0;
 }
 


### PR DESCRIPTION
@pjedge this is just one of many places.  Unfortunately a lot of pipeline software relies on non-zero exit codes to determine if program completed successfully.
